### PR TITLE
Add exception to step result

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "20"
+          node-version: "18"
           cache: "npm"
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "17"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node-version: ["18.x", "20.x"]
+        node-version: ["18.x"]
         include:
           - os: windows-latest
-            node-version: "20.x"
+            node-version: "18.x"
           - os: macos-latest
-            node-version: "20.x"
+            node-version: "18.x"
 
     steps:
       - name: set git core.autocrlf to 'input'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node-version: ["12.x", "14.x", "16.x", "17.x"]
+        node-version: ["18.x", "20.x"]
         include:
           - os: windows-latest
-            node-version: "17.x"
+            node-version: "20.x"
           - os: macos-latest
-            node-version: "17.x"
+            node-version: "20.x"
 
     steps:
       - name: set git core.autocrlf to 'input'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Added
+- Exception to step result ([#78](https://github.com/cucumber/fake-cucumber/pull/78))
+- Upgrade to `@cucumber/messages` `21`
+- Upgrade to `@cucumber/gherkin` `26`
 
 ## [16.0.0] - 2022-06-01
 ### Added

--- a/src/TestStep.ts
+++ b/src/TestStep.ts
@@ -1,4 +1,5 @@
 import * as messages from '@cucumber/messages'
+import { Exception } from '@cucumber/messages'
 
 import { MakeErrorMessage } from './ErrorMessageGenerator'
 import IClock from './IClock'
@@ -10,7 +11,6 @@ import {
   ITestStep,
   IWorld,
 } from './types'
-import { Exception } from '@cucumber/messages'
 
 const { millisecondsToDuration, millisecondsSinceEpochToTimestamp } =
   messages.TimeConversion

--- a/src/TestStep.ts
+++ b/src/TestStep.ts
@@ -10,6 +10,7 @@ import {
   ITestStep,
   IWorld,
 } from './types'
+import { Exception } from '@cucumber/messages'
 
 const { millisecondsToDuration, millisecondsSinceEpochToTimestamp } =
   messages.TimeConversion
@@ -70,6 +71,19 @@ export default abstract class TestStep implements ITestStep {
     }
 
     const start = this.stopwatch.stopwatchNow()
+
+    function makeException(error: Error): Exception {
+      if (error.message) {
+        return {
+          type: error.name,
+          message: error.message,
+        }
+      }
+      return {
+        type: error.name,
+      }
+    }
+
     try {
       world.attach = makeAttach(this.id, testCaseStartedId, listener)
       world.log = (text: string) => {
@@ -99,6 +113,7 @@ export default abstract class TestStep implements ITestStep {
           duration,
           status: messages.TestStepResultStatus.FAILED,
           message,
+          exception: makeException(error),
         },
         listener
       )

--- a/test/TestStepTest.ts
+++ b/test/TestStepTest.ts
@@ -260,6 +260,10 @@ describe('TestStep', () => {
         testStepResult.duration,
         TimeConversion.millisecondsToDuration(0)
       )
+      assert.deepStrictEqual(testStepResult.exception, {
+        type: 'Error',
+        message: 'Should now be run',
+      })
     })
 
     it('returns a TestStepResult with status SKIPPED when the previous step was not passed', async () => {
@@ -288,6 +292,9 @@ describe('TestStep', () => {
         testStepResult.duration,
         TimeConversion.millisecondsToDuration(0)
       )
+      assert.deepStrictEqual(testStepResult.exception, {
+        type: 'Error',
+      })
     })
   })
 })


### PR DESCRIPTION
### 🤔 What's changed?

Added the `Exception` message element when ever a failed step is executed.

### ⚡️ What's your motivation? 

[Implementing a message based JUnit XML Formatter.](https://github.com/cucumber/cucumber-junit-xml-formatter/pull/3).

### 🏷️ What kind of change is this?
- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
