### PR TITLE
emit sourceReference on parameterType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Upgrade to `@cucumber/messages` `21`
+- Add `sourceReference` to `parameterType` ([#90](https://github.com/cucumber/fake-cucumber/pull/90))
 
 ## [16.1.0] - 2022-12-17
 ### Added

--- a/src/SupportCode.ts
+++ b/src/SupportCode.ts
@@ -59,6 +59,7 @@ export default class SupportCode {
     this.parameterTypeMessages.push({
       parameterType: {
         id: this.newId(),
+        sourceReference,
         name: parameterType.name,
         regularExpressions: parameterType.regexpStrings.slice(),
         preferForRegularExpressionMatch: parameterType.preferForRegexpMatch,

--- a/src/SupportCode.ts
+++ b/src/SupportCode.ts
@@ -43,6 +43,7 @@ export default class SupportCode {
   ) {}
 
   public defineParameterType(
+    sourceReference: messages.SourceReference,
     parameterTypeDefinition: IParameterTypeDefinition
   ) {
     const parameterType = new ParameterType<any>(

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -48,7 +48,7 @@ function defineParameterType0(
   parameterTypeDefinition: IParameterTypeDefinition
 ) {
   //@ts-ignore
-  global.supportCode.defineParameterType(parameterTypeDefinition)
+  global.supportCode.defineParameterType(getSourceReference(new Error().stack), parameterTypeDefinition)
 }
 
 function getSourceReference(stackTrace: string): messages.SourceReference {

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -48,7 +48,10 @@ function defineParameterType0(
   parameterTypeDefinition: IParameterTypeDefinition
 ) {
   //@ts-ignore
-  global.supportCode.defineParameterType(getSourceReference(new Error().stack), parameterTypeDefinition)
+  global.supportCode.defineParameterType(
+    getSourceReference(new Error().stack),
+    parameterTypeDefinition
+  )
 }
 
 function getSourceReference(stackTrace: string): messages.SourceReference {

--- a/test/TestPlanTest.ts
+++ b/test/TestPlanTest.ts
@@ -12,6 +12,7 @@ import SupportCode from '../src/SupportCode'
 import TestPlan from '../src/TestPlan'
 import { EnvelopeListener, RunOptions } from '../src/types'
 import { gherkinMessages, streamToArray } from './TestHelpers'
+import { SourceReference } from "@cucumber/messages";
 
 const defaultRunOptions: RunOptions = { allowedRetries: 0 }
 
@@ -157,7 +158,14 @@ describe('TestPlan', () => {
   }
 
   it('defines parameter types', async () => {
-    supportCode.defineParameterType({
+    const sourceReference: SourceReference = {
+      uri: 'path/to/thing.js',
+      location: {
+        line: 5,
+        column: 10,
+      },
+    }
+    supportCode.defineParameterType(sourceReference, {
       name: 'flight',
       regexp: /[A-Z]{3}-[A-Z]{3}/,
       transformer(name) {
@@ -193,6 +201,7 @@ describe('TestPlan', () => {
       .filter((m) => m.parameterType)
       .map((m) => m.parameterType)
     assert.deepStrictEqual(parameterTypes.length, 1)
+    assert.strictEqual(parameterTypes[0].sourceReference, sourceReference)
     assert.strictEqual(parameterTypes[0].name, 'flight')
   })
 

--- a/test/TestPlanTest.ts
+++ b/test/TestPlanTest.ts
@@ -1,5 +1,6 @@
 import { Query } from '@cucumber/gherkin-utils'
 import * as messages from '@cucumber/messages'
+import { SourceReference } from '@cucumber/messages'
 import assert from 'assert'
 
 import { withSourceFramesOnlyStackTrace } from '../src/ErrorMessageGenerator'
@@ -12,7 +13,6 @@ import SupportCode from '../src/SupportCode'
 import TestPlan from '../src/TestPlan'
 import { EnvelopeListener, RunOptions } from '../src/types'
 import { gherkinMessages, streamToArray } from './TestHelpers'
-import { SourceReference } from "@cucumber/messages";
 
 const defaultRunOptions: RunOptions = { allowedRetries: 0 }
 


### PR DESCRIPTION
### 🤔 What's changed?

Include `sourceReference` block in `parameterType` messages.

### ⚡️ What's your motivation? 

Completeness of https://github.com/cucumber/messages/issues/145 - allows us to include a case in the compatibility kit so we can check conformance of implementations.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
