### PR TITLE
support including fileName in attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Support including `fileName` in attachment ([#92](https://github.com/cucumber/fake-cucumber/pull/92))
 
 ## [16.2.0] - 2023-05-13
 ### Added

--- a/src/makeAttach.ts
+++ b/src/makeAttach.ts
@@ -11,7 +11,8 @@ export default function makeAttach(
 ): Attach {
   return function attach(
     data: string | Buffer | Readable,
-    mediaType: string
+    mediaType: string,
+    fileName?: string
   ): void | Promise<void> {
     let body: string
     let contentEncoding: messages.AttachmentContentEncoding
@@ -26,6 +27,7 @@ export default function makeAttach(
           mediaType,
           body,
           contentEncoding,
+          fileName,
         },
       })
     } else if (Buffer.isBuffer(data)) {
@@ -38,6 +40,7 @@ export default function makeAttach(
           mediaType,
           body,
           contentEncoding,
+          fileName,
         },
       })
     } else if (
@@ -67,6 +70,7 @@ export default function makeAttach(
               mediaType,
               body,
               contentEncoding,
+              fileName,
             },
           })
           resolve()

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,8 @@ export interface HookOptions {
 export type AnyBody = (...args: readonly unknown[]) => unknown
 export type Attach = (
   data: string | Buffer | Readable,
-  mediaType: string
+  mediaType: string,
+  fileName?: string
 ) => void | Promise<void>
 export type Log = (text: string) => void | Promise<void>
 

--- a/test/attachTest.ts
+++ b/test/attachTest.ts
@@ -79,7 +79,7 @@ describe('#attach', () => {
     assert.strictEqual(buffer.length, expectedLength)
   })
 
-  it("can optionally include a filename", () => {
+  it('can optionally include a filename', () => {
     const envelopes: messages.Envelope[] = []
     const listener: EnvelopeListener = (envelope: messages.Envelope) =>
       envelopes.push(envelope)
@@ -103,5 +103,5 @@ describe('#attach', () => {
       },
     }
     assert.deepStrictEqual(envelopes[0], expected)
-  });
+  })
 })

--- a/test/attachTest.ts
+++ b/test/attachTest.ts
@@ -26,6 +26,7 @@ describe('#attach', () => {
         testCaseStartedId: 'the-test-case-started-id',
         testStepId: 'the-test-step-id',
         body: 'hello',
+        fileName: undefined,
       },
     }
     assert.deepStrictEqual(envelopes[0], expected)
@@ -52,6 +53,7 @@ describe('#attach', () => {
         testStepId: 'the-test-step-id',
         body: buffer.toString('base64'),
         contentEncoding: messages.AttachmentContentEncoding.BASE64,
+        fileName: undefined,
       },
     }
     assert.deepStrictEqual(envelopes[0], expected)
@@ -76,4 +78,30 @@ describe('#attach', () => {
     const buffer = Buffer.from(envelopes[0].attachment.body, 'base64')
     assert.strictEqual(buffer.length, expectedLength)
   })
+
+  it("can optionally include a filename", () => {
+    const envelopes: messages.Envelope[] = []
+    const listener: EnvelopeListener = (envelope: messages.Envelope) =>
+      envelopes.push(envelope)
+
+    const attach = makeAttach(
+      'the-test-step-id',
+      'the-test-case-started-id',
+      listener
+    )
+
+    attach('hello', 'text/plain', 'hello.txt')
+
+    const expected: messages.Envelope = {
+      attachment: {
+        mediaType: 'text/plain',
+        contentEncoding: messages.AttachmentContentEncoding.IDENTITY,
+        testCaseStartedId: 'the-test-case-started-id',
+        testStepId: 'the-test-step-id',
+        body: 'hello',
+        fileName: 'hello.txt',
+      },
+    }
+    assert.deepStrictEqual(envelopes[0], expected)
+  });
 })


### PR DESCRIPTION
### 🤔 What's changed?

Adds an optional third argument `fileName` to the `attach` function and emits the value as part of the message.

### ⚡️ What's your motivation? 

Makes the reference implementation more complete, allows us to add a scenario to the CCK for fileName.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
