### PR TITLE
feat: include message prop for pending steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Include `message` prop in result for pending steps ([#106](https://github.com/cucumber/fake-cucumber/pull/106))
 
 ## [16.3.0] - 2023-07-03
 ### Added

--- a/src/TestStep.ts
+++ b/src/TestStep.ts
@@ -99,6 +99,10 @@ export default abstract class TestStep implements ITestStep {
         {
           duration,
           status,
+          message:
+            status === messages.TestStepResultStatus.PENDING
+              ? 'TODO'
+              : undefined,
         },
         listener
       )

--- a/test/TestStepTest.ts
+++ b/test/TestStepTest.ts
@@ -219,7 +219,7 @@ describe('TestStep', () => {
       )
     })
 
-    it('returns a TestStepResult with status PENDING when the sole step definitions returns "pending"', async () => {
+    it('returns a TestStepResult with status PENDING and todo message when the sole step definitions returns "pending"', async () => {
       const testStepResult = await pendingPickleTestStep.execute(
         world,
         'some-testCaseStartedId',
@@ -227,6 +227,7 @@ describe('TestStep', () => {
         true
       )
       assert.strictEqual(testStepResult.status, 'PENDING')
+      assert.strictEqual(testStepResult.message, 'TODO')
       assert.notDeepStrictEqual(
         testStepResult.duration,
         TimeConversion.millisecondsToDuration(0)


### PR DESCRIPTION
### 🤔 What's changed?

When a step is pending, include a `message` string in the `TestStepResult` message.

### ⚡️ What's your motivation? 

See https://github.com/cucumber/compatibility-kit/issues/88#issuecomment-1804594923

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
